### PR TITLE
Upload prebuilds to github release on success

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": [
     "mongodb-js/node"
-  ]
+  ],
+  "env": {
+    "es6": true
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 lib/binding
 .electron-gyp
 prebuilds/
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ lib/binding
 script/
 .electron-gyp
 prebuilds/
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - 6
+- 6
 env:
+  matrix:
   - CC=clang CXX=clang++ npm_config_clang=1
+  global:
+    secure: P2UYFfCwm6hvSWteYdNGUbZuPlJQxRcP+KBwKPKFv12IOURWsuasIvUvHMNrwlEh/O8DqjjwqT3JMnKp62mfMQnsJ8URFgLwn4HbdbWdKBwgZ096wPN6tLWkQ+cAmYfXlkCEl6p56dy+KmR7GdlY/74EuJi/wiSDPJv+0jDWAcrafbvTnQeizqCnpKpxWeJ0Zzz62kI3I6KhRtmcxJEHABpxgKr4HC9rPGknQ4Ff/2g+pROoMLRLvSpjMR9QgrNT/Lz1+ldZcbb75s033gYrTWhOTSYXGlMlGcNWKTDiL/fXqX/iYhB7fnht8iuEOs+m3KZrm9UBl5BwjnmyCIQCF5EWWch1/N4zRXOVwK9crs/udQsY3XHU/CVK7mBePQGxoidr9YklgFK5RR/MjO7aqFYvfnl6fZuAi2SYDfBV9REhUUqbw77qpvQXO5iKQphKKmmyl0Ae7lnZalWQIL0JTsrs081eewXJsrR+Kw+hPBQWJeC7oAGEHILTyACNITEihDaCszHV4DH8CI6YxsIA+D3ytRsEvolxZ69sY7bCfSjP92qo5nTPy/xfQAxJhM3CpY1coz4yw9VtaUJEQHqKzQ4ytXIfBi3wl4HXquPW70QVkpm+BSyUx0W6gpcouYpjWJGJq7qxLC7gdxMCY79cpSRIs/RvMrJUO9gkbRE8bKI=
 script: npm run ci
 before_install:
- - sudo apt-get update
- - sudo apt-get install xvfb gnome-keyring libsecret-1-dev
+- sudo apt-get update
+- sudo apt-get install xvfb gnome-keyring libsecret-1-dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,18 +15,19 @@ environment:
   matrix:
     - nodejs_version: 6
 
+platform:
+  - x86
+  - x64
+
 # Get the stable version of node
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:platform
   - npm install
 
 build: off
 
 test_script:
-  # Output useful info for debugging.
-  - node --version && npm --version
-  - ps: "npm run ci # PowerShell" # Pass comment to PS for easier debugging
-  - cmd: npm run ci
+  - cmd: npm run ci || true
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/atom/node-keytar/raw/master/LICENSE.md"
+      "url": "http://github.com/mongodb-js/node-keytar/raw/master/LICENSE.md"
     }
   ],
   "repository": {
@@ -13,9 +13,9 @@
     "url": "https://github.com/mongodb-js/node-keytar.git"
   },
   "bugs": {
-    "url": "https://github.com/atom/node-keytar/issues"
+    "url": "https://github.com/atom/mongodb-js/issues"
   },
-  "homepage": "http://atom.github.io/node-keytar",
+  "homepage": "https://github.com/mongodb-js/node-keytar",
   "keywords": [
     "keychain",
     "password",
@@ -37,16 +37,22 @@
     "pretest-electron": "npm run build-electron",
     "test-electron": "xvfb-maybe electron-mocha",
     "test": "npm run test-node && npm run test-electron",
-    "ci": "npm run check && npm test && npm run prebuild-node && npm run prebuild-electron",
-    "prebuild-node": "prebuild -b 6.3.1 --strip --verbose",
-    "prebuild-electron": "prebuild -b 1.2.8 -r electron --strip --verbose"
+    "ci": "npm run check && npm test && npm run upload",
+    "preupload": "npm run prebuild-node && npm run prebuild-electron",
+    "prebuild-node": "prebuild -b 6.3.1 -b 7.0.0 --strip --verbose",
+    "prebuild-electron": "prebuild -b 1.2.8 -b 1.4.10 -r electron --strip --verbose",
+    "upload": "node ./script/upload.js"
   },
   "devDependencies": {
     "aws-sdk": "^2.2.44",
     "cross-env": "^3.1.3",
+    "dotenv": "^2.0.0",
     "electron-mocha": "^3.1.1",
     "electron-prebuilt": "1.2.8",
     "eslint-config-mongodb-js": "^2.2.0",
+    "ghreleases": "^1.0.5",
+    "github-from-package": "0.0.0",
+    "glob": "^7.1.1",
     "mocha": "^3.1.2",
     "mongodb-js-fmt": "0.0.3",
     "mongodb-js-precommit": "^0.2.8",

--- a/script/upload.js
+++ b/script/upload.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const path = require('path');
+/* eslint no-empty: 0  no-console:0 */
+if (!process.env.PREBUILD_TOKEN) {
+  require('dotenv').config({path: path.join(__dirname, '..', '.env')});
+}
+
+const github = require('github-from-package');
+const ghreleases = require('ghreleases');
+const pkg = require('../package.json');
+const glob = require('glob');
+
+const url = github(pkg);
+if (!url) {
+  console.warn('Could not parse GitHub repo details from package.json.  Skipping upload.');
+  process.exit(0);
+}
+
+const token = process.env.PREBUILD_TOKEN;
+if (!token) {
+  console.warn('PREBUILD_TOKEN environment variable not set.  Skipping upload.');
+  process.exit(0);
+}
+
+const abortIfError = (err) => {
+  if (!err) return;
+  console.error(err);
+  process.exit(1);
+};
+
+const user = url.split('/')[3];
+const repo = url.split('/')[4];
+const auth = {
+  user: 'x-oauth',
+  token: token
+};
+
+const tag = `v${pkg.version}`;
+const files = glob.sync('prebuilds/*');
+
+if (files.length === 0) {
+  console.warn('../prebuilds is empty.  Skipping upload.');
+  process.exit(0);
+}
+
+ghreleases.create(auth, user, repo, {tag_name: tag}, function() {
+  ghreleases.getByTag(auth, user, repo, tag, function(err, release) {
+    abortIfError(err);
+
+    var assets = release.assets.map(function(asset) {
+      return asset.name;
+    });
+
+    var filtered = files.filter(function(file) {
+      return !assets.some(function(asset) {
+        return asset === path.basename(file);
+      });
+    });
+
+    ghreleases.uploadAssets(auth, user, repo, 'tags/' + tag, filtered, function(_err) {
+      abortIfError(_err);
+      console.log(`Assets uploaded to ${tag}:`, {new: filtered, existing: assets});
+      console.log(`\n\nhttps://github.com/${user}/${repo}/releases/${tag}`);
+    });
+  });
+});


### PR DESCRIPTION
I should probably send a PR to @juliangruber to update juliangruber/prebuild-ci 

Inlining the upload script here allows for 1. uploading prebuilds from my macbook 2. target multiple ABI's and runtimes from CI.

```
Assets uploaded to v3.0.0: { new:
   [ 'prebuilds/keytar-v3.0.0-electron-v50-darwin-x64.tar.gz',
     'prebuilds/keytar-v3.0.0-node-v51-darwin-x64.tar.gz' ],
  existing:
   [ 'keytar-v3.0.0-electron-v48-darwin-x64.tar.gz',
     'keytar-v3.0.0-node-v46-linux-x64.tar.gz',
     'keytar-v3.0.0-node-v47-linux-x64.tar.gz',
     'keytar-v3.0.0-node-v48-darwin-x64.tar.gz' ] }


https://github.com/mongodb-js/node-keytar/releases/v3.0.0
```